### PR TITLE
Check if target string is null before replacing

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -48,6 +48,9 @@ export class Inputs {
   }
 
   public render(content: string): string {
+    if (!content) {
+      return ''
+    }
     return content
       .replaceAll('$title', this.title)
       .replaceAll('$description', this.description)


### PR DESCRIPTION
as titled. to avoid null deref errors.