### PR TITLE
Add a null reference check

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -48,6 +48,9 @@ export class Inputs {
   }
 
   public render(content: string): string {
+    if (!content) {
+      return '';
+    }
     return content
       .replaceAll('$title', this.title)
       .replaceAll('$description', this.description)


### PR DESCRIPTION
As titled, prevent exception when the `content` is `null`.